### PR TITLE
Ajustes en propiedad "reference" y en Validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'com.placetopay'
-version = '1.0.8'
+version = '1.0.10'
 
 allprojects {
 	repositories {
@@ -77,7 +77,7 @@ publishing {
 			from components.java
 			groupId 'com.placetopay'
             		artifactId 'java-placetopay'
-            		version '1.0.8'
+            		version '1.0.10'
                         artifact sourcesJar 
                         artifact javadocJar
                         pom.withXml {
@@ -106,10 +106,10 @@ bintray {
                 githubRepo = 'placetopay/java-placetopay' //Optional Github repository
                 githubReleaseNotesFile = 'README.md' //Optional Github readme file
 		version {
-			name = '1.0.8'
+			name = '1.0.10'
 			desc = 'Library to connect with PlacetoPay Redirection service'
 			released = new Date()
-                        vcsTag = '1.0.8'
+                        vcsTag = '1.0.10'
 			attributes = ['gradle-plugin': 'com.use.less:com.use.less.gradle:gradle-useless-plugin']
 		}	
 	}

--- a/src/main/java/com/placetopay/java_placetopay/Contracts/Entity.java
+++ b/src/main/java/com/placetopay/java_placetopay/Contracts/Entity.java
@@ -44,7 +44,7 @@ public abstract class Entity implements HasValidator {
     @Override
     public BaseValidator getValidator() {
         try {
-            if (this.validatorInstance == null)
+            if ((this.validatorInstance == null) && (this.validatorClass != null))
                 this.validatorInstance = (BaseValidator)validatorClass.newInstance();
             return this.validatorInstance;
         } catch (Exception ex) {

--- a/src/main/java/com/placetopay/java_placetopay/Entities/Payment.java
+++ b/src/main/java/com/placetopay/java_placetopay/Entities/Payment.java
@@ -47,7 +47,16 @@ public class Payment extends EntityWithNameValuePair {
     
     public Payment(JSONObject object) {
         super(object);
-        this.reference = object.has("reference") ? object.getString("reference") : null;
+        this.reference = null;
+        if (object.has("reference")) {
+            if (object.get("reference") instanceof String) {
+                this.reference = object.getString("reference");
+            } else {
+                if ((object.get("reference") instanceof Integer)) {
+                    this.reference = String.valueOf(object.getInt("reference"));
+                }
+            }
+        }
         this.allowPartial = object.has("allowPartial") ? object.getBoolean("allowPartial") : false;
         this.description = object.has("description") ? object.getString("description") : null;
         this.amount = object.has("amount") ? new Amount(object.getJSONObject("amount")) : null;

--- a/src/main/java/com/placetopay/java_placetopay/Entities/Payment.java
+++ b/src/main/java/com/placetopay/java_placetopay/Entities/Payment.java
@@ -51,10 +51,8 @@ public class Payment extends EntityWithNameValuePair {
         if (object.has("reference")) {
             if (object.get("reference") instanceof String) {
                 this.reference = object.getString("reference");
-            } else {
-                if ((object.get("reference") instanceof Integer)) {
-                    this.reference = String.valueOf(object.getInt("reference"));
-                }
+            } else if ((object.get("reference") instanceof Long)) {
+                this.reference = String.valueOf(object.getLong("reference"));
             }
         }
         this.allowPartial = object.has("allowPartial") ? object.getBoolean("allowPartial") : false;

--- a/src/main/java/com/placetopay/java_placetopay/Entities/Payment.java
+++ b/src/main/java/com/placetopay/java_placetopay/Entities/Payment.java
@@ -53,6 +53,8 @@ public class Payment extends EntityWithNameValuePair {
                 this.reference = object.getString("reference");
             } else if ((object.get("reference") instanceof Long)) {
                 this.reference = String.valueOf(object.getLong("reference"));
+            } else if ((object.get("reference") instanceof Integer)) {
+                this.reference = String.valueOf(object.getInt("reference"));
             }
         }
         this.allowPartial = object.has("allowPartial") ? object.getBoolean("allowPartial") : false;

--- a/src/main/java/com/placetopay/java_placetopay/Entities/Transaction.java
+++ b/src/main/java/com/placetopay/java_placetopay/Entities/Transaction.java
@@ -92,6 +92,8 @@ public class Transaction extends Entity {
                 this.reference = object.getString("reference");
             } else if ((object.get("reference") instanceof Long)) {
                 this.reference = String.valueOf(object.getLong("reference"));
+            } else if ((object.get("reference") instanceof Integer)) {
+                this.reference = String.valueOf(object.getInt("reference"));
             }
         }
         this.internalReference = object.has("internalReference") ? object.getInt("internalReference") : null;

--- a/src/main/java/com/placetopay/java_placetopay/Entities/Transaction.java
+++ b/src/main/java/com/placetopay/java_placetopay/Entities/Transaction.java
@@ -90,10 +90,8 @@ public class Transaction extends Entity {
         if (object.has("reference")) {
             if (object.get("reference") instanceof String) {
                 this.reference = object.getString("reference");
-            } else {
-                if ((object.get("reference") instanceof Integer)) {
-                    this.reference = String.valueOf(object.getInt("reference"));
-                }
+            } else if ((object.get("reference") instanceof Long)) {
+                this.reference = String.valueOf(object.getLong("reference"));
             }
         }
         this.internalReference = object.has("internalReference") ? object.getInt("internalReference") : null;

--- a/src/main/java/com/placetopay/java_placetopay/Entities/Transaction.java
+++ b/src/main/java/com/placetopay/java_placetopay/Entities/Transaction.java
@@ -52,7 +52,7 @@ public class Transaction extends Entity {
      */
     protected String paymentMethod;
     /**
-     * Nombre del método de pago utilizado 
+     * Nombre del método de pago utilizado
      */
     protected String paymentMethodName;
     /**
@@ -86,7 +86,16 @@ public class Transaction extends Entity {
 
     public Transaction(JSONObject object) {
         this.status = object.has("status") ? new Status(object.getJSONObject("status")) : null;
-        this.reference = object.has("reference") ? object.getString("reference") : null;
+        this.reference = null;
+        if (object.has("reference")) {
+            if (object.get("reference") instanceof String) {
+                this.reference = object.getString("reference");
+            } else {
+                if ((object.get("reference") instanceof Integer)) {
+                    this.reference = String.valueOf(object.getInt("reference"));
+                }
+            }
+        }
         this.internalReference = object.has("internalReference") ? object.getInt("internalReference") : null;
         this.paymentMethod = object.has("paymentMethod") ? object.getString("paymentMethod") : null;
         this.paymentMethodName = object.has("paymentMethodName") ? object.getString("paymentMethodName") : null;
@@ -98,7 +107,7 @@ public class Transaction extends Entity {
         this.refunded = object.has("refunded") ? object.getBoolean("refunded") : false;
         this.processorFields = object.has("processorFields") ? setProcessorFields(object.get("processorFields")) : null;
     }
-        
+
     public Transaction(Status status, String reference, Integer internalReference, String paymentMethod, String paymentMethodName, String issuerName, AmountConversion amount, String authorization, Long receipt, String franchise, boolean refunded, List<NameValuePair> processorFields) {
         this.status = status;
         this.reference = reference;
@@ -209,7 +218,7 @@ public class Transaction extends Entity {
     public List<NameValuePair> getProcessorFields() {
         return processorFields;
     }
-    
+
     /**
      *
      * @param base json content
@@ -218,7 +227,7 @@ public class Transaction extends Entity {
         AmountBase base1 = new AmountBase(base);
         amount = new AmountConversion().setAmountBase(base1);
     }
-    
+
     /**
      *
      * @return Verifica que no hubo un error en la transacción
@@ -226,11 +235,11 @@ public class Transaction extends Entity {
     public boolean isSuccessful() {
         return this.status != null && !this.status.getStatus().equals(Status.ST_ERROR);
     }
-    
+
     public boolean isApproved() {
         return this.status != null && this.status.getStatus().equals(Status.ST_APPROVED);
     }
-    
+
     public JSONArray processorFieldsToArray() {
         JSONArray jsona = new JSONArray();
         for (NameValuePair pair: processorFields) {
@@ -238,11 +247,11 @@ public class Transaction extends Entity {
         }
         return jsona;
     }
-    
+
     private static List<NameValuePair> setProcessorFields(Object json) {
         return Utils.convertToList(json, "item", NameValuePair.class);
     }
-    
+
     public JSONObject additionalData() {
         if (this.processorFields != null) {
             JSONObject object = new JSONObject();


### PR DESCRIPTION
- Fix: En caso de que el Request se haya creado con otra librería y el campo 'reference' sea un Integer, esta librería falla, para esos casos, primero lo parseo a Integer y luego a String.

-Fix: evito NullPointerException en caso que no se tenga Validator.